### PR TITLE
Add dummy OpenAI-compatible FastAPI server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+__pycache__

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,32 @@
+name: Test, Build and Push
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: pytest
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/dummyai:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app app
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,17 +1,45 @@
-# DummyAI  
+# DummyAI
 
-**DummyAI** is an **OpenAI-compatible mock server** built with **FastAPI**.  
-It replicates the OpenAI API surface and returns **schema-valid dummy responses** for all major endpoints, including chat, completions, embeddings, images, audio, files, fine-tuning, and moderations.  
+**DummyAI** is an **OpenAI-compatible mock server** built with **FastAPI**.
+It replicates the OpenAI API surface and returns **schema-valid dummy responses** for major endpoints, including chat, completions, embeddings, images, audio, files, models, fine-tuning, moderations, and more.
 
-## Features  
-- Fully **OpenAI API compatible**  
-- **Dummy responses** with valid JSON schema  
-- **Streaming simulation** (SSE) for chat completions  
-- **File upload support** with placeholder IDs  
-- Lightweight, configurable, and **open source**  
+## Features
+- Fully **OpenAI API compatible**
+- **Dummy responses** with valid JSON schema
+- **Streaming simulation** (SSE) for chat completions
+- **File upload support** with placeholder IDs
+- **Model listing** and retrieval endpoints
+- Lightweight, configurable, and **open source**
+- Image APIs return base64-encoded sample PNGs
+## Supported endpoints
+- `GET /v1/models`, `GET /v1/models/{model}`
+- `POST /v1/chat/completions` (streaming)
+- `POST /v1/completions`
+- `POST /v1/embeddings`
+- `POST /v1/images/generations`, `POST /v1/images/edits`, `POST /v1/images/variations`
+- `POST /v1/audio/transcriptions`, `POST /v1/audio/translations`
+- `POST /v1/files`, `GET /v1/files`, `GET/DELETE /v1/files/{id}`
+- `POST /v1/fine_tuning/jobs`, `GET /v1/fine_tuning/jobs`, `GET /v1/fine_tuning/jobs/{id}`
+- `POST /v1/moderations`
+- `POST /v1/edits`
 
-## Use cases  
-- Develop OpenAI-based apps **without real API calls**  
-- Run in **CI/CD pipelines** for integration testing  
-- Work **offline** without API keys or credits  
-- Simulate errors or edge cases safely  
+## Use cases
+- Develop OpenAI-based apps **without real API calls**
+- Run in **CI/CD pipelines** for integration testing
+- Work **offline** without API keys or credits
+- Simulate errors or edge cases safely
+
+## Run locally
+```bash
+uvicorn app.main:app --reload
+```
+
+## Docker
+Build and run the container:
+```bash
+docker build -t dummyai .
+docker run -p 8000:8000 dummyai
+```
+
+## GitHub Actions
+The workflow in `.github/workflows/docker.yml` runs the test suite and, on success, builds the image and pushes it to Docker Hub. Set `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets in your repository to enable it.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,229 @@
+from fastapi import FastAPI, Request, UploadFile, File
+from fastapi.responses import JSONResponse
+from sse_starlette.sse import EventSourceResponse
+import asyncio
+import json
+import time
+
+
+# base64-encoded 1x1 PNG
+_SAMPLE_IMAGE_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII="
+)
+
+
+def _count_tokens(text: str) -> int:
+    """Naively count tokens by splitting on whitespace."""
+    if not isinstance(text, str):
+        return 0
+    return len(text.split())
+
+
+def _calc_usage(prompt_text: str, completion_text: str) -> dict:
+    prompt_tokens = _count_tokens(prompt_text)
+    completion_tokens = _count_tokens(completion_text)
+    return {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": prompt_tokens + completion_tokens,
+    }
+
+app = FastAPI(title="DummyAI")
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+@app.post("/v1/chat/completions")
+async def chat_completions(request: Request):
+    body = await request.json()
+    model = body.get("model", "dummy-model")
+    completion_text = "Hello this is a dummy response."
+    prompt_text = " ".join(m.get("content", "") for m in body.get("messages", []))
+    usage = _calc_usage(prompt_text, completion_text)
+    if body.get("stream"):
+        async def event_generator():
+            for token in completion_text.split():
+                chunk = {
+                    "id": "chatcmpl-dummy",
+                    "object": "chat.completion.chunk",
+                    "created": _now(),
+                    "model": model,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"content": token + " "},
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+                yield json.dumps(chunk)
+                await asyncio.sleep(0.05)
+            final_chunk = {
+                "id": "chatcmpl-dummy",
+                "object": "chat.completion.chunk",
+                "created": _now(),
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": usage,
+            }
+            yield json.dumps(final_chunk)
+            yield "[DONE]"
+        return EventSourceResponse(event_generator())
+
+    resp = {
+        "id": "chatcmpl-dummy",
+        "object": "chat.completion",
+        "created": _now(),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": completion_text},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": usage,
+    }
+    return JSONResponse(resp)
+
+
+@app.get("/v1/models")
+async def list_models():
+    return JSONResponse({"object": "list", "data": [{"id": "dummy-model", "object": "model"}]})
+
+
+@app.get("/v1/models/{model_id}")
+async def retrieve_model(model_id: str):
+    return JSONResponse({"id": model_id, "object": "model", "owned_by": "dummy"})
+
+
+@app.post("/v1/completions")
+async def completions(request: Request):
+    body = await request.json()
+    prompt_field = body.get("prompt", "")
+    if isinstance(prompt_field, list):
+        prompt_text = " ".join(p for p in prompt_field if isinstance(p, str))
+    elif isinstance(prompt_field, str):
+        prompt_text = prompt_field
+    else:
+        prompt_text = ""
+    completion_text = "dummy completion"
+    usage = _calc_usage(prompt_text, completion_text)
+    resp = {
+        "id": "cmpl-dummy",
+        "object": "text_completion",
+        "created": _now(),
+        "model": "dummy-model",
+        "choices": [
+            {
+                "index": 0,
+                "text": completion_text,
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": usage,
+    }
+    return JSONResponse(resp)
+
+
+@app.post("/v1/embeddings")
+async def embeddings(request: Request):
+    body = await request.json()
+    input_field = body.get("input", "")
+    if isinstance(input_field, list):
+        prompt_text = " ".join(str(i) for i in input_field)
+    else:
+        prompt_text = str(input_field)
+    tokens = _count_tokens(prompt_text)
+    resp = {
+        "object": "list",
+        "data": [{"object": "embedding", "index": 0, "embedding": [0.0, 0.0, 0.0]}],
+        "model": "dummy-embedding-model",
+        "usage": {"prompt_tokens": tokens, "total_tokens": tokens},
+    }
+    return JSONResponse(resp)
+
+
+@app.post("/v1/images/generations")
+async def images():
+    resp = {
+        "created": _now(),
+        "data": [{"b64_json": _SAMPLE_IMAGE_B64}],
+    }
+    return JSONResponse(resp)
+
+
+@app.post("/v1/images/edits")
+async def images_edits():
+    resp = {"created": _now(), "data": [{"b64_json": _SAMPLE_IMAGE_B64}]}
+    return JSONResponse(resp)
+
+
+@app.post("/v1/images/variations")
+async def images_variations():
+    resp = {"created": _now(), "data": [{"b64_json": _SAMPLE_IMAGE_B64}]}
+    return JSONResponse(resp)
+
+
+@app.post("/v1/audio/transcriptions")
+async def audio_transcriptions(file: UploadFile = File(...)):
+    return JSONResponse({"text": "dummy transcription"})
+
+
+@app.post("/v1/audio/translations")
+async def audio_translations(file: UploadFile = File(...)):
+    return JSONResponse({"text": "dummy translation"})
+
+
+@app.post("/v1/files")
+async def files(file: UploadFile = File(...)):
+    return JSONResponse({"id": "file-dummy", "object": "file", "filename": file.filename})
+
+
+@app.get("/v1/files")
+async def list_files():
+    return JSONResponse({"object": "list", "data": [{"id": "file-dummy", "object": "file"}]})
+
+
+@app.get("/v1/files/{file_id}")
+async def retrieve_file(file_id: str):
+    return JSONResponse({"id": file_id, "object": "file", "filename": "dummy.txt"})
+
+
+@app.delete("/v1/files/{file_id}")
+async def delete_file(file_id: str):
+    return JSONResponse({"id": file_id, "object": "file", "deleted": True})
+
+
+@app.post("/v1/fine_tuning/jobs")
+async def fine_tuning_jobs():
+    return JSONResponse({"id": "ft-job-dummy", "object": "fine_tuning.job"})
+
+
+@app.get("/v1/fine_tuning/jobs")
+async def list_ft_jobs():
+    return JSONResponse({"object": "list", "data": [{"id": "ft-job-dummy", "object": "fine_tuning.job"}]})
+
+
+@app.get("/v1/fine_tuning/jobs/{job_id}")
+async def retrieve_ft_job(job_id: str):
+    return JSONResponse({"id": job_id, "object": "fine_tuning.job", "status": "succeeded"})
+
+
+@app.post("/v1/moderations")
+async def moderations():
+    return JSONResponse({"id": "modr-dummy", "model": "dummy-moderation", "results": [{"flagged": False}]})
+
+
+@app.post("/v1/edits")
+async def edits():
+    return JSONResponse({"object": "edit", "choices": [{"text": "dummy edit"}]})
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+sse-starlette
+httpx
+python-multipart

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,62 @@
+import os
+import sys
+import base64
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app.main import app
+
+client = TestClient(app)
+
+def test_list_models():
+    resp = client.get("/v1/models")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["data"][0]["id"] == "dummy-model"
+
+def test_retrieve_model():
+    resp = client.get("/v1/models/dummy-model")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == "dummy-model"
+
+
+def test_chat_usage_counts():
+    body = {"model": "dummy-model", "messages": [{"role": "user", "content": "Hello world"}]}
+    resp = client.post("/v1/chat/completions", json=body)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["usage"] == {
+        "prompt_tokens": 2,
+        "completion_tokens": len("Hello this is a dummy response.".split()),
+        "total_tokens": 2 + len("Hello this is a dummy response.".split()),
+    }
+
+
+def test_completion_usage_counts():
+    body = {"prompt": "Hi there"}
+    resp = client.post("/v1/completions", json=body)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["usage"] == {
+        "prompt_tokens": 2,
+        "completion_tokens": len("dummy completion".split()),
+        "total_tokens": 2 + len("dummy completion".split()),
+    }
+
+
+def test_embedding_usage_counts():
+    body = {"input": "hi"}
+    resp = client.post("/v1/embeddings", json=body)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["usage"] == {"prompt_tokens": 1, "total_tokens": 1}
+
+
+def test_image_generation_returns_base64():
+    resp = client.post("/v1/images/generations")
+    assert resp.status_code == 200
+    data = resp.json()
+    img_b64 = data["data"][0]["b64_json"]
+    img_bytes = base64.b64decode(img_b64)
+    assert len(img_bytes) > 0


### PR DESCRIPTION
## Summary
- implement FastAPI app that mocks OpenAI endpoints with model listing and other common routes
- compute usage tokens from request/response content for chat, completion, and embedding APIs
- add tests verifying usage token counts
- return base64-encoded sample images for generation endpoints
- run pytest in CI before building and pushing Docker image to Docker Hub

## Testing
- `python -m py_compile app/main.py`
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac0d2c5310832eb76f3cadfe3433f7